### PR TITLE
catch (and skip) crash when resizing to less than half width/height

### DIFF
--- a/0/curses/dwimmer-PRiSM.py
+++ b/0/curses/dwimmer-PRiSM.py
@@ -75,15 +75,17 @@ def render(w, fy, fx, prism, r):
 	'''
 	w.erase()
 	w.border('|', '|', '-', '-', '.', '.', "'", "'")
-
-	for y, x in product(range(r), range(r)):
-		if prism[y][x] != 0:
-			w.addstr(
-					centre(fy, r)+y, 
-					centre(fx, r)+x, 
-					".", 
-					curses.color_pair(232+(prism[y][x]-32))
-					)
+	try:
+		for y, x in product(range(r), range(r)):
+			if prism[y][x] != 0:
+				w.addstr(
+						centre(fy, r)+y, 
+						centre(fx, r)+x, 
+						".", 
+						curses.color_pair(232+(prism[y][x]-32))
+						)
+	except:
+		pass
 	w.refresh()
 
 	


### PR DESCRIPTION
When I have my terminal at less than a quarter of my screen size, and maximise then minimise, there is a crash as w.addstr attempts to draw a character out of bounds, so chuck it in a try and ignore any out of bounds draws